### PR TITLE
fixed bug when prepare_receptor -C and receptor has no charges

### DIFF
--- a/AutoDockTools/MoleculePreparation.py
+++ b/AutoDockTools/MoleculePreparation.py
@@ -225,7 +225,7 @@ class AutoDockMoleculePreparation:
         #MODE SWITCH 2: adding charges????  ||NOT IN USE||
         if debug: print("self.chargeType=", self.chargeType)
         if self.chargeType is None:
-            len_zero_charges = len([x for x in mol.chains.residues.atoms if x.charge==0])
+            len_zero_charges = len([x for x in mol.chains.residues.atoms if x._charges.values()=={}])Z
             if len_zero_charges==len(mol.allAtoms):
                 print("WARNING: all atoms in '%s' had zero charges! Adding gasteiger charges..."%mol.name)
                 chargeCalculator = self.chargeCalculator = GasteigerChargeCalculator()
@@ -236,6 +236,8 @@ class AutoDockMoleculePreparation:
                     #charges could come from file or ?
                     print("WARNING: some atoms in '%s' had no charge! Adding gasteiger charges to all..."%mol.name)
                 if debug: print("no change to charges!")
+                chargeCalculator = self.chargeCalculator = GasteigerChargeCalculator()
+                chargeCalculator.addCharges(mol.allAtoms)
             self.chargeType = mol.allAtoms[0].chargeSet
         else:
             chargeCalculator.addCharges(mol.allAtoms)


### PR DESCRIPTION
When prepare_receptor.py is launch using -C flag rise a keyError:
Here's the whole error trace:
Traceback (most recent call last):

  File "C:\Users\o_o\Documents\PythonProjects\02_chemioinformatics\00_programs\autodockpy37\autodocktools-prepare-py3k-master\autodocktools_prepare_py3k\AutoDockTools\Utilities24\prepare4.py", line 181, in <module>
    prepare_receptor4(receptor,charges_to_add=None, verbose=True)

  File "C:\Users\o_o\Documents\PythonProjects\02_chemioinformatics\00_programs\autodockpy37\autodocktools-prepare-py3k-master\autodocktools_prepare_py3k\AutoDockTools\Utilities24\prepare4.py", line 166, in prepare_receptor4
    RPO = AD4ReceptorPreparation(mol, mode, repairs, charges_to_add,

  File "C:\Users\o_o\Documents\PythonProjects\02_chemioinformatics\00_programs\autodockpy37\autodocktools-prepare-py3k-master\autodocktools_prepare_py3k\AutoDockTools\MoleculePreparation.py", line 552, in __init__
    AutoDockMoleculePreparation.__init__(self, molecule,

  File "C:\Users\o_o\Documents\PythonProjects\02_chemioinformatics\00_programs\autodockpy37\autodocktools-prepare-py3k-master\autodocktools_prepare_py3k\AutoDockTools\MoleculePreparation.py", line 141, in __init__
    self.addCharges(mol, charges_to_add)

  File "C:\Users\o_o\Documents\PythonProjects\02_chemioinformatics\00_programs\autodockpy37\autodocktools-prepare-py3k-master\autodocktools_prepare_py3k\AutoDockTools\MoleculePreparation.py", line 212, in addCharges
    len_zero_charges = len([x for x in mol.chains.residues.atoms if x.charge==0])

  File "C:\Users\o_o\Documents\PythonProjects\02_chemioinformatics\00_programs\autodockpy37\autodocktools-prepare-py3k-master\autodocktools_prepare_py3k\AutoDockTools\MoleculePreparation.py", line 212, in <listcomp>
    len_zero_charges = len([x for x in mol.chains.residues.atoms if x.charge==0])

  File "C:\Users\o_o\Documents\PythonProjects\02_chemioinformatics\00_programs\autodockpy37\autodocktools-prepare-py3k-master\autodocktools_prepare_py3k\MolKit\molecule.py", line 407, in __getattr__
    return self._charges[self.chargeSet]

KeyError: None