### PR TITLE
Fixed issue when there are no CD atoms on a N-terminal Proline

### DIFF
--- a/MolKit/chargeCalculator.py
+++ b/MolKit/chargeCalculator.py
@@ -181,7 +181,7 @@ atom._charge dictionary and to set the atom.chargeSet to self.chtype
             # FIX THIS what if no CD?
             # CDatom = nres.atoms.get('CD')[0]
             CDatom = nres.atoms.get('CD')
-            if CDatom is not None:
+            if CDatom is not None and len(CDatom.data) != 0:
                 CDatom = CDatom[0]
                 CDatom._charges['Kollman'] = CDatom._charges['Kollman'] + .029
             else:


### PR DESCRIPTION
When there are no CD atoms on a Proline, the object returned by `nres.atoms.get('CD')` is not `None` but an empty `AtomSet` object. Thus we must check `len(CDatoms.data)` instead.